### PR TITLE
Fix: Center social media icons on mobile screen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -576,7 +576,7 @@ h1::before {
        padding-left: 625px;
        overflow:auto;
        background: transparent;
-  
+
        padding-top: 50px;
        padding-bottom: 50px;
      }
@@ -1830,9 +1830,24 @@ h1::before {
   h1 {
     font-size: 3rem;
   }
-  
+
+  h2{
+    font-size:1rem;
+    width:calc(100% + 20px);
+  }
+
   .container .box {
     padding-top: 40px;
     height: 100%;
   }
+
+  .so .wrapper{
+    padding-left: 5px;
+    padding-right: 5px;
+    display: flex;
+    align-items: center;
+    justify-content:center;
+  }
+
+
 }


### PR DESCRIPTION

issue: #58

## Description

_Initailly the padding is 120px which was too wide for the mobile screen, but was okay for the desktop view On mobile i give it a padding left and right of 5px which centered the social media icons on mobile screen<br />

Fixes #58

## Mentions

@PGautam27 

## Screenshots of relevant screens

_Add screenshots of relevant screens_

#### Before Fix
![195849481-7a9ee2ec-fb8f-4203-9bdf-b8738039c158](https://user-images.githubusercontent.com/58771507/195967716-d2763956-1531-4490-afd6-5be1f022f924.png)

#### After Fix
![195849167-5872057b-cf31-4625-bcd3-fa904577da01](https://user-images.githubusercontent.com/58771507/195967734-4e4610ec-648c-49fc-b22e-44d48ec13ff7.png)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
