### PR TITLE
text aligment fixed

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -218,7 +218,9 @@ h1::before {
    padding: 10px 0px;
    align-content: center;
  }
+ /* text aligment issue fix */
  .container .box .content h2{
+  white-space: nowrap;
   font-size: 0.85em;
   font-family: 'Poppins', 'Roboto', Nunito;
 


### PR DESCRIPTION
## Description

I have fixed the text-overflow issue by making some minor changes in the "h2" heading of content (
used (white-space as nowrap) specifies how whitespace is handled in an element.), And it all worked 
Fixes #[ISSUENO]

## Screenshots of relevant screens
Before fix 
![image](https://user-images.githubusercontent.com/98846260/195976029-8d833885-7f8d-4240-b719-82516f48d7c9.png)


_Add screenshots of relevant screens_
After fix
![image](https://user-images.githubusercontent.com/98846260/195976100-89b61560-2593-4e69-b8cb-fb5b3c320a6a.png)


## Developer's checklist

- [ ] My PR follows the style guidelines of this project
- [ ] I have performed a self-check on my work

**If changes are made in the code:**

- [ ] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [ ] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [ ] I have added test cases to show that my feature works
- [ ] I have added relevant screenshots in my PR
