### PR TITLE
Fix: Inconsistency of bubble plus  icon on mobile screen

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -736,14 +736,9 @@ h1::before {
   opacity: 0;
 }
 
-<--flexcard-->
 
-{
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  font-family: consolas;
-}
+
+
 
 .containerms body
 {
@@ -1489,12 +1484,12 @@ h1::before {
      margin: 10px 0;
      align-items: center;
      text-align: left;
+     gap:3px;
    }
    .accordion .icon{
      margin: 0 15px 0 0;
      width: 50px; 
      border-radius: 50%;
-     float: left;
      background:  8px 5px white;
    }
    .accordion .active .icon{
@@ -1504,7 +1499,7 @@ h1::before {
      content: '\002B'; /*+ sign*/
      font-weight: 1000;
      font-size: 30px;
-     margin-left: 15px;/*placement of icon inside the white circle*/
+     margin-left: 13.5px;/*placement of icon inside the white circle*/
      transition: all .5s ease;
      color: black;
    }
@@ -1851,5 +1846,11 @@ h1::before {
     justify-content:center;
   }
 
-
+ 
+  .accordion h5{
+    max-width: 210px;
+    width:100%;
+    font-size: 19px; /*font size of questions*/
+  }
+ 
 }


### PR DESCRIPTION
The inconsistency was cause by the sixe of the text in the FAQ .accordion h5 class. so i gave it a max-width to maintain consistency of the text width
amd also reduced the font size by 3px so it firts the mobile screen, this approched fixed the issue
issue: #60

## Description

_Give a summary of the change that you have made_ <br />

Fixes #60

## Mentions
@PGautam27  

## Screenshots of relevant screens
#### Before the fix
![image](https://user-images.githubusercontent.com/58771507/196298606-d4fd4603-4ef4-4f50-9ceb-2560d9f6002a.png)

#### After the Fix
![image](https://user-images.githubusercontent.com/58771507/196298716-59a6f219-65ae-4d06-b95e-7b993986b5ed.png)


## Developer's checklist

- [x] My PR follows the style guidelines of this project
- [x] I have performed a self-check on my work

**If changes are made in the code:**

- [x] I have followed the [coding guidelines](https://google.github.io/styleguide/jsguide.html)
- [x] My changes in code generate no new warnings
- [ ] My changes are breaking another fix/feature of the project
- [x] I have added test cases to show that my feature works
- [x] I have added relevant screenshots in my PR
